### PR TITLE
More robust trill/wavy-line duplicate detection

### DIFF
--- a/musicxml2ly_conversion.py
+++ b/musicxml2ly_conversion.py
@@ -1211,7 +1211,7 @@ articulations_dict = {
     #"toe": "?",
     "turn": "turn",
     "tremolo": musicxml_tremolo_to_lily_event,
-    "trill-mark": "trill",
+    "trill-mark": lambda notations: None if notations.get_named_children ('wavy-line') else "trill",
     #"triple-tongue": "?",
     #"unstress": "?"
     "up-bow": "upbow",
@@ -1239,20 +1239,17 @@ def OrnamenthasWhat(mxl_event):
     elif wavy == True: return "wave"
     elif trilly == True: return "trill"
 
-def OrnamenthasWavyline(mxl_event):
-    for i in mxl_event._parent._children:
-            if i._name == "wavy-line": return True
-    return False
 
-
-def musicxml_articulation_to_lily_event(mxl_event):
+def musicxml_articulation_to_lily_event(mxl_event, parent_node):
     # wavy-line elements are treated as trill spanners, not as articulation ornaments
     if mxl_event.get_name() in articulation_spanners:
         return musicxml_spanner_to_lily_event(mxl_event)
 
     tmp_tp = articulations_dict.get(mxl_event.get_name())
-    if OrnamenthasWavyline(mxl_event):
-        return
+
+    if hasattr (tmp_tp, '__call__'):
+        tmp_tp = tmp_tp(parent_node)
+
     if not tmp_tp:
         return
 
@@ -2571,7 +2568,7 @@ def musicxml_voice_to_lily_voice(voice):
 
             # accidental-marks are direct children of <notation>!
             for a in notations.get_named_children('accidental-mark'):
-                ev = musicxml_articulation_to_lily_event(a)
+                ev = musicxml_articulation_to_lily_event(a, notations)
                 if ev:
                     ev_chord.append(ev)
 
@@ -2596,7 +2593,7 @@ def musicxml_voice_to_lily_voice(voice):
 
             for a in ornaments:
                 for ch in a.get_all_children():
-                    ev = musicxml_articulation_to_lily_event(ch)
+                    ev = musicxml_articulation_to_lily_event(ch, a)
                     if ev:
                         ev_chord.append(ev)
 


### PR DESCRIPTION
Make sure non-`<trill-mark>` ornaments get converted even if there is a `<wavy-line>` ornament as well.  Test case:

[wavy-line.xml.txt](https://github.com/Philomelos/lilypond-musicxml2ly-dev/files/61026/wavy-line.xml.txt)

<sup>Stupid issue tracker doesn't allow attaching XML, so I named it `.txt`</sup>
